### PR TITLE
Modified Terminal-Icons.format.ps1xml to format Length property

### DIFF
--- a/Terminal-Icons/Terminal-Icons.format.ps1xml
+++ b/Terminal-Icons/Terminal-Icons.format.ps1xml
@@ -3,213 +3,270 @@
 <!-- Based on the format.ps1xml file from DirColors
 https://github.com/DHowett/DirColors -->
 <Configuration>
-    <SelectionSets>
-        <SelectionSet>
-            <Name>FileSystemTypes</Name>
-            <Types>
-                <TypeName>System.IO.DirectoryInfo</TypeName>
-                <TypeName>System.IO.FileInfo</TypeName>
-            </Types>
-        </SelectionSet>
-    </SelectionSets>
+	<SelectionSets>
+		<SelectionSet>
+			<Name>FileSystemTypes</Name>
+			<Types>
+				<TypeName>System.IO.DirectoryInfo</TypeName>
+				<TypeName>System.IO.FileInfo</TypeName>
+			</Types>
+		</SelectionSet>
+	</SelectionSets>
 
-    <Controls>
-        <Control>
-            <Name>FileSystemTypes-GroupingFormat</Name>
-            <CustomControl>
-                <CustomEntries>
-                    <CustomEntry>
-                        <CustomItem>
-                            <Frame>
-                                <LeftIndent>4</LeftIndent>
-                                <CustomItem>
-                                    <Text AssemblyName="System.Management.Automation" BaseName="FileSystemProviderStrings" ResourceId="DirectoryDisplayGrouping"/>
-                                    <ExpressionBinding>
-                                        <ScriptBlock>
-                                                  $_.PSParentPath.Replace("Microsoft.PowerShell.Core\FileSystem::", "")
-                                        </ScriptBlock>
-                                    </ExpressionBinding>
-                                    <NewLine/>
-                                </CustomItem>
-                            </Frame>
-                        </CustomItem>
-                    </CustomEntry>
-                </CustomEntries>
-            </CustomControl>
-        </Control>
-    </Controls>
+	<Controls>
+		<Control>
+			<Name>FileSystemTypes-GroupingFormat</Name>
+			<CustomControl>
+				<CustomEntries>
+					<CustomEntry>
+						<CustomItem>
+							<Frame>
+								<LeftIndent>4</LeftIndent>
+								<CustomItem>
+									<Text AssemblyName="System.Management.Automation" BaseName="FileSystemProviderStrings" ResourceId="DirectoryDisplayGrouping"/>
+									<ExpressionBinding>
+										<ScriptBlock>
+												  $_.PSParentPath.Replace("Microsoft.PowerShell.Core\FileSystem::", "")
+										</ScriptBlock>
+									</ExpressionBinding>
+									<NewLine/>
+								</CustomItem>
+							</Frame>
+						</CustomItem>
+					</CustomEntry>
+				</CustomEntries>
+			</CustomControl>
+		</Control>
+	</Controls>
 
-    <ViewDefinitions>
-        <View>
-            <Name>children</Name>
-            <ViewSelectedBy>
-                <SelectionSetName>FileSystemTypes</SelectionSetName>
-            </ViewSelectedBy>
-            <GroupBy>
-                <PropertyName>PSParentPath</PropertyName>
-                <CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
-            </GroupBy>
-            <TableControl>
-                <TableHeaders>
-                    <TableColumnHeader>
-                        <Label>Mode</Label>
-                        <Width>7</Width>
-                        <Alignment>left</Alignment>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>LastWriteTime</Label>
-                        <Width>25</Width>
-                        <Alignment>right</Alignment>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Length</Label>
-                        <Width>14</Width>
-                        <Alignment>right</Alignment>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Label>Name</Label>
-                    </TableColumnHeader>
-                </TableHeaders>
-                <TableRowEntries>
-                    <TableRowEntry>
-                        <Wrap/>
-                        <TableColumnItems>
-                            <TableColumnItem>
-                                <PropertyName>Mode</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    [String]::Format('{0,10}  {1,8}', $_.LastWriteTime.ToString('d'), $_.LastWriteTime.ToString('t'))
-                                </ScriptBlock>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Length</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <ScriptBlock>
-                                    Terminal-Icons\Format-TerminalIcons $_
-                                </ScriptBlock>
-                            </TableColumnItem>
-                        </TableColumnItems>
-                    </TableRowEntry>
-                </TableRowEntries>
-            </TableControl>
-        </View>
-        <View>
-            <Name>children</Name>
-            <ViewSelectedBy>
-                <SelectionSetName>FileSystemTypes</SelectionSetName>
-            </ViewSelectedBy>
-            <GroupBy>
-                <PropertyName>PSParentPath</PropertyName>
-                <CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
-            </GroupBy>
-            <ListControl>
-                <ListEntries>
-                    <ListEntry>
-                        <EntrySelectedBy>
-                            <TypeName>System.IO.FileInfo</TypeName>
-                        </EntrySelectedBy>
-                        <ListItems>
-                            <ListItem>
-                                <Label>Name</Label>
-                                <ScriptBlock>
-                                    Terminal-Icons\Format-TerminalIcons $_
-                                </ScriptBlock>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>Length</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>CreationTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LastWriteTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LastAccessTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>Mode</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LinkType</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <Label>Target</Label>
-                                <ScriptBlock>
-                                    Terminal-Icons\Format-TerminalIcons $_
-                                </ScriptBlock>
-                            </ListItem>
-                            <!-- <ListItem>
-                                <PropertyName>VersionInfo</PropertyName>
-                            </ListItem> -->
-                        </ListItems>
-                    </ListEntry>
-                    <ListEntry>
-                        <ListItems>
-                            <ListItem>
-                                <Label>Name</Label>
-                                <ScriptBlock>
-                                    Terminal-Icons\Format-TerminalIcons $_
-                                </ScriptBlock>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>CreationTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LastWriteTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LastAccessTime</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>Mode</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <PropertyName>LinkType</PropertyName>
-                            </ListItem>
-                            <ListItem>
-                                <Label>Target</Label>
-                                <ScriptBlock>
-                                Terminal-Icons\Format-TerminalIcons $_
-                                </ScriptBlock>
-                            </ListItem>
-                        </ListItems>
-                    </ListEntry>
-                </ListEntries>
-            </ListControl>
-        </View>
-        <View>
-            <Name>children</Name>
-            <ViewSelectedBy>
-                <SelectionSetName>FileSystemTypes</SelectionSetName>
-            </ViewSelectedBy>
-            <GroupBy>
-                <PropertyName>PSParentPath</PropertyName>
-                <CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
-            </GroupBy>
-            <WideControl>
-                <WideEntries>
-                    <WideEntry>
-                        <WideItem>
-                            <ScriptBlock>
-                                Terminal-Icons\Format-TerminalIcons $_
-                            </ScriptBlock>
-                        </WideItem>
-                    </WideEntry>
-                    <WideEntry>
-                        <EntrySelectedBy>
-                            <TypeName>System.IO.DirectoryInfo</TypeName>
-                        </EntrySelectedBy>
-                        <WideItem>
-                            <ScriptBlock>
-                                Terminal-Icons\Format-TerminalIcons $_
-                            </ScriptBlock>
-                        </WideItem>
-                    </WideEntry>
-                </WideEntries>
-            </WideControl>
-        </View>
-    </ViewDefinitions>
+	<ViewDefinitions>
+		<View>
+			<Name>children</Name>
+			<ViewSelectedBy>
+				<SelectionSetName>FileSystemTypes</SelectionSetName>
+			</ViewSelectedBy>
+			<GroupBy>
+				<PropertyName>PSParentPath</PropertyName>
+				<CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
+			</GroupBy>
+			<TableControl>
+				<TableHeaders>
+					<TableColumnHeader>
+						<Label>Mode</Label>
+						<Width>7</Width>
+						<Alignment>left</Alignment>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>LastWriteTime</Label>
+						<Width>25</Width>
+						<Alignment>right</Alignment>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Length</Label>
+						<Width>14</Width>
+						<Alignment>right</Alignment>
+					</TableColumnHeader>
+					<TableColumnHeader>
+						<Label>Name</Label>
+					</TableColumnHeader>
+				</TableHeaders>
+				<TableRowEntries>
+					<TableRowEntry>
+						<Wrap/>
+						<TableColumnItems>
+							<TableColumnItem>
+								<PropertyName>Mode</PropertyName>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>
+									[String]::Format('{0,10}  {1,8}', $_.LastWriteTime.ToString('d'), $_.LastWriteTime.ToString('t'))
+								</ScriptBlock>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>
+                                    if ($_.GetType().Name -eq 'FileInfo'){
+									    "{0:N2} {1}" -f $(
+										    if ($_.Length -lt 1kb) { $_.length, 'B' }
+										    elseif ($_.length -lt 1mb) { ($_.length/1kb), 'KB' }
+										    elseif ($_.length -lt 1gb) { ($_.length/1mb), 'MB' }
+									    )
+                                    }
+                                    else{
+                                        $objFSO = New-Object -com  Scripting.FileSystemObject
+	                                    $folder=$objFSO.GetFolder($_.FullName)
+	                                    if ($folder.SubFolders.Count -eq 0){
+		                                    $s = $folder.Size 
+                                            "{0:N2} {1}" -f $(
+			                                    if ($s -lt 1kb) { $s, 'B' }
+			                                    elseif ($s -lt 1mb) { ($s/1kb), 'KB' }
+			                                    elseif ($s -lt 1gb) { ($s/1mb), 'MB' }
+		                                    )
+	                                    }
+	                                    else{
+		                                    $s = ($folder.SubFolders | Measure-Object Size -Sum).Sum
+                                            "{0:N2} {1}" -f $(
+			                                    if ($s -lt 1kb) { $s, 'B' }
+			                                    elseif ($s -lt 1mb) { ($s/1kb), 'KB' }
+			                                    elseif ($s -lt 1gb) { ($s/1mb), 'MB' }
+		                                    )
+	                                    }
+                                    }
+								</ScriptBlock>
+							</TableColumnItem>
+							<TableColumnItem>
+								<ScriptBlock>
+									Terminal-Icons\Format-TerminalIcons $_
+								</ScriptBlock>
+							</TableColumnItem>
+						</TableColumnItems>
+					</TableRowEntry>
+				</TableRowEntries>
+			</TableControl>
+		</View>
+		<View>
+			<Name>children</Name>
+			<ViewSelectedBy>
+				<SelectionSetName>FileSystemTypes</SelectionSetName>
+			</ViewSelectedBy>
+			<GroupBy>
+				<PropertyName>PSParentPath</PropertyName>
+				<CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
+			</GroupBy>
+			<ListControl>
+				<ListEntries>
+					<ListEntry>
+						<EntrySelectedBy>
+							<TypeName>System.IO.FileInfo</TypeName>
+						</EntrySelectedBy>
+						<ListItems>
+							<ListItem>
+								<Label>Name</Label>
+								<ScriptBlock>
+									Terminal-Icons\Format-TerminalIcons $_
+								</ScriptBlock>
+							</ListItem>
+							<ListItem>
+								<Label>Length</Label>
+								<ScriptBlock>
+									if ($_.GetType().Name -eq 'FileInfo'){
+									    "{0:N2} {1}" -f $(
+										    if ($_.Length -lt 1kb) { $_.length, 'B' }
+										    elseif ($_.length -lt 1mb) { ($_.length/1kb), 'KB' }
+										    elseif ($_.length -lt 1gb) { ($_.length/1mb), 'MB' }
+									    )
+                                    }
+                                    else{
+                                        $objFSO = New-Object -com  Scripting.FileSystemObject
+	                                    $folder=$objFSO.GetFolder($_.FullName)
+	                                    if ($folder.SubFolders.Count -eq 0){
+		                                    $s = $folder.Size 
+                                            "{0:N2} {1}" -f $(
+			                                    if ($s -lt 1kb) { $s, 'B' }
+			                                    elseif ($s -lt 1mb) { ($s/1kb), 'KB' }
+			                                    elseif ($s -lt 1gb) { ($s/1mb), 'MB' }
+		                                    )
+	                                    }
+	                                    else{
+		                                    $s = ($folder.SubFolders | Measure-Object Size -Sum).Sum
+                                            "{0:N2} {1}" -f $(
+			                                    if ($s -lt 1kb) { $s, 'B' }
+			                                    elseif ($s -lt 1mb) { ($s/1kb), 'KB' }
+			                                    elseif ($s -lt 1gb) { ($s/1mb), 'MB' }
+		                                    )
+	                                    }
+                                    }
+								</ScriptBlock>
+							</ListItem>
+							<ListItem>
+								<PropertyName>CreationTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LastWriteTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LastAccessTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>Mode</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LinkType</PropertyName>
+							</ListItem>
+							<ListItem>
+								<Label>Target</Label>
+								<ScriptBlock>
+									Terminal-Icons\Format-TerminalIcons $_
+								</ScriptBlock>
+							</ListItem>
+							<!-- <ListItem>
+								<PropertyName>VersionInfo</PropertyName>
+							</ListItem> -->
+						</ListItems>
+					</ListEntry>
+					<ListEntry>
+						<ListItems>
+							<ListItem>
+								<Label>Name</Label>
+								<ScriptBlock>
+									Terminal-Icons\Format-TerminalIcons $_
+								</ScriptBlock>
+							</ListItem>
+							<ListItem>
+								<PropertyName>CreationTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LastWriteTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LastAccessTime</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>Mode</PropertyName>
+							</ListItem>
+							<ListItem>
+								<PropertyName>LinkType</PropertyName>
+							</ListItem>
+							<ListItem>
+								<Label>Target</Label>
+								<ScriptBlock>
+								Terminal-Icons\Format-TerminalIcons $_
+								</ScriptBlock>
+							</ListItem>
+						</ListItems>
+					</ListEntry>
+				</ListEntries>
+			</ListControl>
+		</View>
+		<View>
+			<Name>children</Name>
+			<ViewSelectedBy>
+				<SelectionSetName>FileSystemTypes</SelectionSetName>
+			</ViewSelectedBy>
+			<GroupBy>
+				<PropertyName>PSParentPath</PropertyName>
+				<CustomControlName>FileSystemTypes-GroupingFormat</CustomControlName>
+			</GroupBy>
+			<WideControl>
+				<WideEntries>
+					<WideEntry>
+						<WideItem>
+							<ScriptBlock>
+								Terminal-Icons\Format-TerminalIcons $_
+							</ScriptBlock>
+						</WideItem>
+					</WideEntry>
+					<WideEntry>
+						<EntrySelectedBy>
+							<TypeName>System.IO.DirectoryInfo</TypeName>
+						</EntrySelectedBy>
+						<WideItem>
+							<ScriptBlock>
+								Terminal-Icons\Format-TerminalIcons $_
+							</ScriptBlock>
+						</WideItem>
+					</WideEntry>
+				</WideEntries>
+			</WideControl>
+		</View>
+	</ViewDefinitions>
 </Configuration>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Modified Terminal-Icons.format.ps1xml to format output of Length property into B|KB|MB|GB respectively.
## Description
<!--- Describe your changes in detail -->
This adds a formatted Length output for files and directories (including sub-folders). Makes the output slower (though it's reasonably fast even for bigger folders), but also adds useful more readable info. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/devblackops/Terminal-Icons/issues/9

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

