### PR TITLE
Add python and java file extensions to theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1] 2020-11-29
+
+### Added
+
+- New icons and colors for Python (.py) and Java (.java) files.
+
 ## [0.2.0] 2020-11-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.2.1] 2020-11-29
+## [0.2.1] Unreleased
 
 ### Added
 

--- a/Terminal-Icons/Data/colorThemes/devblackops.psd1
+++ b/Terminal-Icons/Data/colorThemes/devblackops.psd1
@@ -162,6 +162,12 @@
             '.esx'                  = 'F0E68C'
             '.mjs'                  = 'F0E68C'
 
+            # Java
+            '.java'                 = 'F89820'
+
+            # Python
+            '.py'                   = '4B8BBE'
+
             # React
             '.jsx'                  = '20B2AA'
             '.tsx'                  = '20B2AA'

--- a/Terminal-Icons/Data/iconThemes/devblackops.psd1
+++ b/Terminal-Icons/Data/iconThemes/devblackops.psd1
@@ -165,6 +165,12 @@
             '.esx'                  = 'nf-dev-javascript'
             '.mjs'                  = 'nf-dev-javascript'
 
+            # Java
+            '.java'                 = 'nf-dev-java'
+
+            # Python
+            '.py'                   = 'nf-dev-python'
+
             # React
             '.jsx'                  = 'nf-dev-react'
             '.tsx'                  = 'nf-dev-react'

--- a/Terminal-Icons/Terminal-Icons.psd1
+++ b/Terminal-Icons/Terminal-Icons.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Terminal-Icons.psm1'
-    ModuleVersion     = '0.2.0'
+    ModuleVersion     = '0.2.1'
     GUID              = '4419ddb6-3528-47cd-baf3-7fb9d8566620'
     Author            = 'Brandon Olin'
     CompanyName       = 'Community'


### PR DESCRIPTION
Fixes #16. Adds Python (.py) and Java (.java) file extensions to theme.

![image](https://user-images.githubusercontent.com/12634452/100562349-4927c080-3270-11eb-9bbd-d652e95e0427.png)
