### PR TITLE
Add Set-TerminalIconsIcon, Get-TerminalIconsGlyphs

### DIFF
--- a/Terminal-Icons/Public/Get-TerminalIconsGlyphs.ps1
+++ b/Terminal-Icons/Public/Get-TerminalIconsGlyphs.ps1
@@ -1,0 +1,27 @@
+﻿function Get-TerminalIconsGlyphs {
+    <#
+    .SYNOPSIS
+        Gets the list of glyphs known to Terminal-Icons.
+    .DESCRIPTION
+        Gets a hashtable with the available glyph names and icons. Useful in creating a custom theme.
+    .EXAMPLE
+        PS> Get-TerminalIconsGlyphs
+
+        Gets the table of glyph names and icons.
+    .INPUTS
+        None.
+    .OUTPUTS
+        None.
+    .LINK
+        Get-TerminalIconsIconTheme
+    .LINK
+        Set-TerminalIconsIcon
+    #>
+    [cmdletbinding()]
+    param()
+
+    # This is also helpful for argument completers needing glyphs -
+    # ArgumentCompleterAttribute isn't able to access script variables but it
+    # CAN call commands.
+    $script:glyphs
+}

--- a/Terminal-Icons/Public/Set-TerminalIconsIcon.ps1
+++ b/Terminal-Icons/Public/Set-TerminalIconsIcon.ps1
@@ -1,0 +1,134 @@
+﻿function Set-TerminalIconsIcon {
+    <#
+    .SYNOPSIS
+        Set a specific icon in the current Terminal-Icons icon theme or allows
+        swapping one glyph for another.
+    .DESCRIPTION
+        Set the Terminal-Icons icon for a specific file/directory or glyph to a
+        named glyph.
+
+        Also allows all uses of a specific glyph to be replaced with a different
+        glyph.
+    .PARAMETER Directory
+        The well-known directory name to match for the icon.
+    .PARAMETER FileName
+        The well-known file name to match for the icon.
+    .PARAMETER FileExtension
+        The file extension to match for the icon.
+    .PARAMETER NewGlyph
+        The name of the new glyph to use when swapping.
+    .PARAMETER Glyph
+        The name of the glyph to use; or, when swapping glyphs, the name of the
+        glyph you want to change.
+    .PARAMETER Force
+        Bypass confirmation messages.
+    .EXAMPLE
+        PS> Set-TerminalIconsIcon -FileName "README.md" -Glyph "nf-fa-file_text"
+
+        Set README.md files to display a text file icon.
+    .EXAMPLE
+        PS> Set-TerminalIconsIcon -FileExtension ".xml" -Glyph "nf-mdi-file_xml"
+
+        Set XML files to display an XML file icon.
+    .EXAMPLE
+        PS> Set-TerminalIconsIcon -Directory ".github" -Glyph "nf-mdi-github_face"
+
+        Set directories named ".github" to display an Octocat face icon.
+    .EXAMPLE
+        PS> Set-TerminalIconsIcon -Glyph "nf-mdi-xml" -NewGlyph "nf-mdi-file_xml"
+
+        Changes all uses of the "nf-mdi-xml" double-wide glyph to be the "nf-mdi-file_xml"
+        single-width XML file glyph.
+    .INPUTS
+        None.
+
+        The command does not accept pipeline input.
+    .OUTPUTS
+        None.
+    .LINK
+        Get-TerminalIconsIconTheme
+    .LINK
+        Get-TerminalIconsTheme
+    .LINK
+        Get-TerminalIconsGlyphs
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = "ArgumentCompleter parameters don't all get used.")]
+    [cmdletbinding(SupportsShouldProcess, DefaultParameterSetName = "FileExtension")]
+    param(
+        [Parameter(ParameterSetName = "Directory", Mandatory)]
+        [ArgumentCompleter( {
+                param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+                (Get-TerminalIconsIconTheme).Values.Types.Directories.WellKnown.Keys | Where-Object { $_ -like "$wordToComplete*" } | Sort-Object
+            })]
+        [ValidateNotNullOrEmpty()]
+        [string]$Directory,
+
+        [Parameter(ParameterSetName = "FileName", Mandatory)]
+        [ArgumentCompleter( {
+                param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+                (Get-TerminalIconsIconTheme).Values.Types.Files.WellKnown.Keys | Where-Object { $_ -like "$wordToComplete*" } | Sort-Object
+            })]
+        [ValidateNotNullOrEmpty()]
+        [string]$FileName,
+
+        [Parameter(ParameterSetName = "FileExtension", Mandatory)]
+        [ArgumentCompleter( {
+                param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+                (Get-TerminalIconsIconTheme).Values.Types.Files.Keys | Where-Object { $_.StartsWith(".") -and $_ -like "$wordToComplete*" } | Sort-Object
+            })]
+        [ValidatePattern("^\.")]
+        [string]$FileExtension,
+
+        [Parameter(ParameterSetName = "SwapGlyph", Mandatory)]
+        [ArgumentCompleter( {
+                param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+                (Get-TerminalIconsGlyphs).Keys | Where-Object { $_ -like "*$wordToComplete*" } | Sort-Object
+            })]
+        [ValidateNotNullOrEmpty()]
+        [string]$NewGlyph,
+
+        [Parameter(Mandatory)]
+        [ArgumentCompleter( {
+                param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+                (Get-TerminalIconsGlyphs).Keys | Where-Object { $_ -like "*$wordToComplete*" } | Sort-Object
+            })]
+        [ValidateNotNullOrEmpty()]
+        [string]$Glyph,
+
+        [switch]$Force
+    )
+
+    If($PSCmdlet.ParameterSetName -eq "Directory") {
+        If ($Force -or $PSCmdlet.ShouldProcess("$Directory = $Glyph", 'Set well-known directory icon')) {
+            (Get-TerminalIconsIconTheme).Values.Types.Directories.WellKnown[$Directory] = $Glyph
+        }
+    }
+    ElseIf ($PSCmdlet.ParameterSetName -eq "FileName") {
+        If ($Force -or $PSCmdlet.ShouldProcess("$FileName = $Glyph", 'Set well-known file name icon')) {
+            (Get-TerminalIconsIconTheme).Values.Types.Files.WellKnown[$FileName] = $Glyph
+        }
+    }
+    ElseIf ($PSCmdlet.ParameterSetName -eq "FileExtension") {
+        If ($Force -or $PSCmdlet.ShouldProcess("$FileExtension = $Glyph", 'Set file extension icon')) {
+            (Get-TerminalIconsIconTheme).Values.Types.Files[$FileExtension] = $Glyph
+        }
+    }
+    ElseIf ($PSCmdlet.ParameterSetName -eq "SwapGlyph") {
+        If ($Force -or $PSCmdlet.ShouldProcess("$Glyph to $NewGlyph", 'Swap glyph usage')) {
+            # Directories
+            $toModify = (Get-TerminalIconsTheme).Icon.Types.Directories.WellKnown
+            $keys = $toModify.Keys | Where-Object { $toModify[$_] -eq $Glyph }
+            $keys | ForEach-Object { $toModify[$_] = $NewGlyph }
+
+            # Files
+            $toModify = (Get-TerminalIconsTheme).Icon.Types.Files.WellKnown
+            $keys = $toModify.Keys | Where-Object { $toModify[$_] -eq $Glyph }
+            $keys | ForEach-Object { $toModify[$_] = $NewGlyph }
+
+            # Extensions
+            $toModify = (Get-TerminalIconsTheme).Icon.Types.Files
+            $keys = $toModify.Keys | Where-Object { $_.StartsWith(".") -and $toModify[$_] -eq $Glyph }
+            $keys | ForEach-Object { $toModify[$_] = $NewGlyph }
+        }
+    }
+}

--- a/Terminal-Icons/Terminal-Icons.psd1
+++ b/Terminal-Icons/Terminal-Icons.psd1
@@ -15,9 +15,11 @@
         'Add-TerminalIconsIconTheme'
         'Format-TerminalIcons'
         'Get-TerminalIconsColorTheme'
+        'Get-TerminalIconsGlyphs'
         'Get-TerminalIconsIconTheme'
         'Get-TerminalIconsTheme'
         'Set-TerminalIconsColorTheme'
+        'Set-TerminalIconsIcon'
         'Set-TerminalIconsIconTheme'
         'Show-TerminalIconsTheme'
     )
@@ -34,5 +36,3 @@
         }
     }
 }
-
-

--- a/docs/en-US/Get-TerminalIconsGlyphs.md
+++ b/docs/en-US/Get-TerminalIconsGlyphs.md
@@ -1,0 +1,50 @@
+---
+external help file: Terminal-Icons-help.xml
+Module Name: Terminal-Icons
+online version:
+schema: 2.0.0
+---
+
+# Get-TerminalIconsGlyphs
+
+## SYNOPSIS
+Gets the list of glyphs known to Terminal-Icons.
+
+## SYNTAX
+
+```
+Get-TerminalIconsGlyphs [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets a hashtable with the available glyph names and icons.
+Useful in creating a custom theme.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-TerminalIconsGlyphs
+```
+
+Gets the table of glyph names and icons.
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None.
+## OUTPUTS
+
+### None.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerminalIconsIconTheme]()
+
+[Set-TerminalIconsIcon]()
+

--- a/docs/en-US/Set-TerminalIconsIcon.md
+++ b/docs/en-US/Set-TerminalIconsIcon.md
@@ -1,0 +1,218 @@
+---
+external help file: Terminal-Icons-help.xml
+Module Name: Terminal-Icons
+online version:
+schema: 2.0.0
+---
+
+# Set-TerminalIconsIcon
+
+## SYNOPSIS
+Set a specific icon in the current Terminal-Icons icon theme or allows
+swapping one glyph for another.
+
+## SYNTAX
+
+### FileExtension (Default)
+```
+Set-TerminalIconsIcon -FileExtension <String> -Glyph <String> [-Force] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+### Directory
+```
+Set-TerminalIconsIcon -Directory <String> -Glyph <String> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### FileName
+```
+Set-TerminalIconsIcon -FileName <String> -Glyph <String> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### SwapGlyph
+```
+Set-TerminalIconsIcon -NewGlyph <String> -Glyph <String> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set the Terminal-Icons icon for a specific file/directory or glyph to a
+named glyph.
+
+Also allows all uses of a specific glyph to be replaced with a different
+glyph.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerminalIconsIcon -FileName "README.md" -Glyph "nf-fa-file_text"
+```
+
+Set README.md files to display a text file icon.
+
+### EXAMPLE 2
+```
+Set-TerminalIconsIcon -FileExtension ".xml" -Glyph "nf-mdi-file_xml"
+```
+
+Set XML files to display an XML file icon.
+
+### EXAMPLE 3
+```
+Set-TerminalIconsIcon -Directory ".github" -Glyph "nf-mdi-github_face"
+```
+
+Set directories named ".github" to display an Octocat face icon.
+
+### EXAMPLE 4
+```
+Set-TerminalIconsIcon -Glyph "nf-mdi-xml" -NewGlyph "nf-mdi-file_xml"
+```
+
+Changes all uses of the "nf-mdi-xml" double-wide glyph to be the "nf-mdi-file_xml"
+single-width XML file glyph.
+
+## PARAMETERS
+
+### -Directory
+The well-known directory name to match for the icon.
+
+```yaml
+Type: String
+Parameter Sets: Directory
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileName
+The well-known file name to match for the icon.
+
+```yaml
+Type: String
+Parameter Sets: FileName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileExtension
+The file extension to match for the icon.
+
+```yaml
+Type: String
+Parameter Sets: FileExtension
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewGlyph
+The name of the new glyph to use when swapping.
+
+```yaml
+Type: String
+Parameter Sets: SwapGlyph
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Glyph
+The name of the glyph to use; or, when swapping glyphs, the name of the
+glyph you want to change.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Bypass confirmation messages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None.
+### The command does not accept pipeline input.
+## OUTPUTS
+
+### None.
+## NOTES
+
+## RELATED LINKS
+
+[Get-TerminalIconsIconTheme]()
+
+[Get-TerminalIconsTheme]()
+
+[Get-TerminalIconsGlyphs]()
+


### PR DESCRIPTION
## Description

`Get-TerminalIconsGlyphs` allows users to see the available glyph set for easier theme customization. It also allows argument completion over the set of available glyphs.

`Set-TerminalIconsIcon` allows users to update an existing file name, file extension, or directory name to use a different icon. It also allows users to "swap" one glyph for another in the current theme, which allows streamlined theme customization.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Partially addresses #34 - allows users to more easily customize a theme to change icons that don't render properly in their given terminal.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Creating a new theme is somewhat challenging and requires a non-trivial amount of spelunking to figure out the right structure for the files/directories, the available set of glyphs, etc. These changes can help with that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Testing environment:
- Mac OS Big Sur 11.2.3
- PowerShell 7.1.3
- iTerm2
- Fira Code Nerd Font

`Get-TerminalIconsGlyphs` was tested locally and is also part of the argument completer for glyph parameters in `Set-TerminalIconsIcon`.

`Set-TerminalIconsIcon` was tested locally using all parameter sets against the default `devblackops` theme. Argument completers were also validated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Notes:

- It doesn't seem there's a good pattern for testing changes to the current theme. I didn't try to invent that pattern, but if there's a suggestion I'm glad to add some Pester tests.
- This doesn't include the ability to modify the symbolic link icons for either files or directories. I thought it was getting a little cluttered. It could easily be added later.
- I didn't add the ability to _remove_ an icon from the current theme. I figured that might be a `Remove-TerminalIconsIcon` command, which could be added later. However, you can use the `Set` command here to _add new ones_.
- On build I get a warning from the PSScriptAnalyzer about needing to include a UTF BOM in the .psm1 file. I'll include that below. I didn't modify the .psm1 file so I assume this has something to do with the build and possibly Mac OS. I did notice on clone that the .psm1 and .psd1 do not have a BOM; perhaps a .gitattributes update and an .editorconfig could help.

Warning from PSScriptAnalyzer:

```text
RuleName                      Severity ScriptName          Line Message
--------                      -------- ----------          ---- -------
PSUseBOMForUnicodeEncodedFile Warning  Terminal-Icons.psm1      Missing BOM encoding for non-ASCII encoded file
                                                                'Terminal-Icons.psm1'
```