### PR TITLE
Remove Pester and platyPS as build dependencies

### DIFF
--- a/requirements.psd1
+++ b/requirements.psd1
@@ -1,21 +1,11 @@
 @{
-    PSDependOptions = @{
+    PSDependOptions  = @{
         Target = 'CurrentUser'
     }
-    BuildHelpers = @{
-        Version = '2.0.16'
-    }
-    Pester = @{
-        Parameters = @{
-            MinimumVersion = '5.3.0'
-            SkipPublisherCheck = $true
-        }
-    }
-    platyPS = '0.14.1'
-    PowerHtml = 'latest'
-    PowerShellBuild = @{
-        RequiredVersion = '0.6.1'
-    }
-    psake = '4.9.0'
+    BuildHelpers     = '2.0.16'
+    platyPS          = '0.14.1'
+    PowerHtml        = 'latest'
+    PowerShellBuild  = '0.6.1'
+    psake            = '4.9.0'
     PSScriptAnalyzer = '1.19.1'
 }

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -3,7 +3,6 @@
         Target = 'CurrentUser'
     }
     BuildHelpers     = '2.0.16'
-    platyPS          = '0.14.1'
     PowerHtml        = 'latest'
     PowerShellBuild  = '0.6.1'
     psake            = '4.9.0'


### PR DESCRIPTION
## Description
Pester and platyPS are already installed and loaded on GH Actions. Trying to load them again raises an error because the assemblies are already loaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

