### PR TITLE
Added light theme

### DIFF
--- a/Terminal-Icons/Data/colorThemes/devblackops_light.psd1
+++ b/Terminal-Icons/Data/colorThemes/devblackops_light.psd1
@@ -24,9 +24,9 @@
         songs                   = 'DB7093'
         onedrive                = 'b0b0b0'
         downloads               = 'b0b0b0'
-        src                     = '00e672'
-        development             = '00e672'
-        projects                = '00e672'
+        src                     = '00cd65'
+        development             = '00cd65'
+        projects                = '00cd65'
         bin                     = '00FFF7'
         tests                   = '87CEEB'
         windows                 = '00A8E8'
@@ -326,9 +326,9 @@
       '.lua'                  = '87CEFA'
 
       # Clojure
-      '.clj'                  = '00e672'
-      '.cljs'                 = '00e672'
-      '.cljc'                 = '00e672'
+      '.clj'                  = '00cd65'
+      '.cljs'                 = '00cd65'
+      '.cljc'                 = '00cd65'
 
       # Groovy
       '.groovy'               = '87CEFA'


### PR DESCRIPTION
Light theme was based off devblackops theme. Tested against a light grey background (RGB: 235,235,235). Darkened the colors that were not too visible on the screen.

## Related Issue
https://github.com/devblackops/Terminal-Icons/issues/69

## Motivation and Context
I am a light theme terminal user, and I feel that this colorscheme will be beneficial to other light theme users like me.