### PR TITLE
Add benchmark folder icon and color

### DIFF
--- a/Terminal-Icons/Data/colorThemes/devblackops.psd1
+++ b/Terminal-Icons/Data/colorThemes/devblackops.psd1
@@ -8,6 +8,7 @@
                 docs                    = '00BFFF'
                 documents               = '00BFFF'
                 desktop                 = '00FBFF'
+                benchmark               = 'F08519'
                 contacts                = '00FBFF'
                 apps                    = 'FF143C'
                 applications            = 'FF143C'

--- a/Terminal-Icons/Data/colorThemes/devblackops_light.psd1
+++ b/Terminal-Icons/Data/colorThemes/devblackops_light.psd1
@@ -8,6 +8,7 @@
         docs                    = '00BFFF'
         documents               = '00BFFF'
         desktop                 = '00c9cd'
+        benchmark               = 'F08519'
         contacts                = '00c9cd'
         apps                    = 'FF143C'
         applications            = 'FF143C'

--- a/Terminal-Icons/Data/iconThemes/devblackops.psd1
+++ b/Terminal-Icons/Data/iconThemes/devblackops.psd1
@@ -10,6 +10,7 @@
                 docs                    = 'nf-oct-repo'
                 documents               = 'nf-oct-repo'
                 desktop                 = 'nf-mdi-desktop_classic'
+                benchmark               = 'nf-mdi-timer'
                 contacts                = 'nf-mdi-contacts'
                 apps                    = 'nf-mdi-apps'
                 applications            = 'nf-mdi-apps'


### PR DESCRIPTION
I would like to add the benchmark folder icon `nf-mdi-timer` and color `F08519` to your terminal-icons also. 

![image](https://user-images.githubusercontent.com/10666633/201718463-3cb5eb0a-1a63-453a-91bb-03f2f5dcc3ab.png)
