### PR TITLE
Use 'UnixMode' on *nix platforms instead of Windows-only 'Mode'

### DIFF
--- a/Terminal-Icons/Terminal-Icons.format.ps1xml
+++ b/Terminal-Icons/Terminal-Icons.format.ps1xml
@@ -53,7 +53,7 @@ https://github.com/DHowett/DirColors -->
                 <TableHeaders>
                     <TableColumnHeader>
                         <Label>Mode</Label>
-                        <Width>7</Width>
+                        <Width>10</Width>
                         <Alignment>left</Alignment>
                     </TableColumnHeader>
                     <TableColumnHeader>
@@ -75,7 +75,9 @@ https://github.com/DHowett/DirColors -->
                         <Wrap/>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Mode</PropertyName>
+                                <ScriptBlock>
+                                    if ($isWindows) {$_.Mode} else {$_.UnixMode}
+                                </ScriptBlock>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <ScriptBlock>
@@ -164,7 +166,9 @@ https://github.com/DHowett/DirColors -->
                                 <PropertyName>LastAccessTime</PropertyName>
                             </ListItem>
                             <ListItem>
-                                <PropertyName>Mode</PropertyName>
+                                <ScriptBlock>
+                                    if ($isWindows) {$_.Mode} else {$_.UnixMode}
+                                </ScriptBlock>
                             </ListItem>
                             <ListItem>
                                 <PropertyName>LinkType</PropertyName>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I had to increase the width of the `Mode` colum to `10` (was `7`), otherwise it wraps. We can not add a switch on the OS in the definition of this width, the XML schema would not allow that; we could create format on the fly, but that seems like significant refactoring with possible impact on `gci`'s latency.

Otherwise, the change is a simple switch over the OS to select an appropriate property of the file to be rendered.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#66 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows showing *nix file permissions on non-windows platforms.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on my Debian. The tests run by `./build.ps1` are all green, the imported module shows unix permissions/windows permissions depending on the platform.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

