### PR TITLE
Add `Set-TerminalIconPathResolver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Set-TerminalIconsColorTheme | **DEPRECATED** Set the Terminal-Icons color theme.
 Set-TerminalIconsIconTheme  | **DEPRECATED** Set the Terminal-Icons icon theme.
 Set-TerminalIconsTheme      | Set the Terminal-Icons icon and/or color theme.
 Show-TerminalIconsTheme     | List example directories and files to show the currently applied color and icon themes.
+Set-TerminalIconPathResolver| Set the path resolver script block to handle target of symlinks before it be display.
 
 ## Screenshots
 

--- a/Terminal-Icons/Private/Resolve-Icon.ps1
+++ b/Terminal-Icons/Private/Resolve-Icon.ps1
@@ -41,7 +41,7 @@ function Resolve-Icon {
                 } else {
                     $colorSet = $script:colorReset
                 }
-                $displayInfo['Target'] = ' ' + $glyphs['nf-md-arrow_right_thick'] + ' ' + $FileInfo.Target
+                $displayInfo['Target'] = ' ' + $glyphs['nf-md-arrow_right_thick'] + ' ' + (&$script:PathResolver $FileInfo.Target)
                 break
             }
             'SymbolicLink' {
@@ -55,7 +55,7 @@ function Resolve-Icon {
                 } else {
                     $colorSet = $script:colorReset
                 }
-                $displayInfo['Target'] = ' ' + $glyphs['nf-md-arrow_right_thick'] + ' ' + $FileInfo.Target
+                $displayInfo['Target'] = ' ' + $glyphs['nf-md-arrow_right_thick'] + ' ' + (&$script:PathResolver $FileInfo.Target)
                 break
             } default {
                 if ($icons) {

--- a/Terminal-Icons/Private/Set-PathResolver.ps1
+++ b/Terminal-Icons/Private/Set-PathResolver.ps1
@@ -1,0 +1,19 @@
+function Set-PathResolver {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowNull()]
+        [scriptblock]$Resolver
+    )
+
+    if(-not $PathResolver) {
+        $script:PathResolver = {
+            param($Path)
+            $Path
+        }
+    }
+    else{
+        $script:PathResolver = $Resolver
+    }
+}

--- a/Terminal-Icons/Public/Set-TerminalIconPathResolver.ps1
+++ b/Terminal-Icons/Public/Set-TerminalIconPathResolver.ps1
@@ -1,0 +1,34 @@
+function Set-TerminalIconPathResolver {
+    <#
+    .SYNOPSIS
+        Set the path resolver for processing symbol's target before displaying.
+    .DESCRIPTION
+        Set the path resolver for processing symbol's target before displaying.
+    .PARAMETER Resolver
+        The path resolver to set.
+    .EXAMPLE
+        PS> Set-TerminalIconPathResolver -Resolver { param($Path) $Path.Replace($HOME, '~') }
+
+        Set the path resolver to replace the home directory with '~'.
+    .INPUTS
+        ScriptBlock
+
+        You can pipe a scriptblock to this function.
+    .OUTPUTS
+        None.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification='Implemented in private function')]
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [AllowNull()]
+        [scriptblock]$Resolver
+    )
+
+    process {
+        Set-PathResolver -Resolver $Resolver
+    }
+}

--- a/Terminal-Icons/Terminal-Icons.psm1
+++ b/Terminal-Icons/Terminal-Icons.psm1
@@ -24,6 +24,10 @@ $userThemeData = @{
         Icon  = @{}
     }
 }
+$PathResolver = {
+    param($Path)
+    $Path
+}
 
 # Import builtin icon/color themes and convert colors to escape sequences
 $colorSequences = @{}

--- a/docs/en-US/Set-TerminalIconPathResolver.md
+++ b/docs/en-US/Set-TerminalIconPathResolver.md
@@ -1,0 +1,107 @@
+---
+external help file: Terminal-Icons-help.xml
+Module Name: Terminal-Icons
+online version:
+schema: 2.0.0
+---
+
+# Set-TerminalIconPathResolver
+
+## SYNOPSIS
+Set the path resolver for processing symbol's target before displaying.
+
+## SYNTAX
+
+```
+Set-TerminalIconPathResolver [-Resolver] <ScriptBlock> [-ProgressAction <ActionPreference>] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Set the path resolver for processing symbol's target before displaying.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Set-TerminalIconPathResolver -Resolver { param($Path) $Path.Replace($HOME, '~') }
+```
+
+Set the path resolver to replace the home directory with '~'.
+
+## PARAMETERS
+
+### -Resolver
+The path resolver to set.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### ScriptBlock
+### You can pipe a scriptblock to this function.
+## OUTPUTS
+
+### None.
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
Allows the user to handle `$FileInfo.Target` before displaying it.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows the user to process `$FileInfo.Target` before displaying it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#123 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'd like to be able to provide additional interfaces to allow other code to hook `Resolve-Icon` with respect to `symlink`/`junction` handling.

Example:
![image](https://github.com/devblackops/Terminal-Icons/assets/31927825/eb1407a8-2cf5-4ca0-9d71-af0fb9a4306f)
My profile treats the root path of msys as `/` and would like to be able to hook code to change `-> E:\msys\usr\bin` to `-> /usr/bin`

Extra example:
![image](https://github.com/devblackops/Terminal-Icons/assets/31927825/ca03d62a-e1f9-427c-a2ae-c90877fd9709)
I wish I could show it as `~/Documents/workstation/` instead of the full path, by a hook

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
https://github.com/steve02081504/Terminal-Icons/actions/runs/7438998284
CI works

## Screenshots (if appropriate):
![图片](https://github.com/devblackops/Terminal-Icons/assets/31927825/09a49f5a-527d-4635-acb0-a1aa4dbf32cf)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

