### PR TITLE
Add zero prefix to individual rgb values so length of each values is always 2

### DIFF
--- a/Terminal-Icons/Private/ConvertFrom-ColorEscapeSequence.ps1
+++ b/Terminal-Icons/Private/ConvertFrom-ColorEscapeSequence.ps1
@@ -14,6 +14,10 @@ function ConvertFrom-ColorEscapeSequence {
         $g   = '{0:x}' -f [int]$arr[3]
         $b   = '{0:x}' -f [int]$arr[4].TrimEnd('m')
 
+        if ($r.Length -eq 1) { $r = '0'+$r }
+        if ($g.Length -eq 1) { $g = '0'+$g }
+        if ($b.Length -eq 1) { $b = '0'+$b }
+
         ($r + $g + $b).ToUpper()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Improve conversion from base 10 to base 16.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When converting rgb values <= 15 to hex, they only have a length of 1. E.g. "15 -> F".
This commit adds a prefix 0 for hex values with a length of 1.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing different input values and and checking the output that is returned.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

