### PR TITLE
Support powershell in constrained mode

### DIFF
--- a/Terminal-Icons/Terminal-Icons.psm1
+++ b/Terminal-Icons/Terminal-Icons.psm1
@@ -11,7 +11,7 @@
 # })
 
 $moduleRoot    = $PSScriptRoot
-$glyphs        = . $moduleRoot/Data/glyphs.ps1
+$glyphs        = Invoke-Expression "& $moduleRoot/Data/glyphs.ps1"
 $escape        = [char]27
 $colorReset    = "${escape}[0m"
 $defaultTheme  = 'devblackops'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In highly secure environments, powershell can be configured to run in [constrained mode](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/).
In this mode, the `dot` evaluator is not permitted to run.

## Description
<!--- Describe your changes in detail -->
This change uses `Invoke-Expression` to achieve the same behavior as before but allows for the module to work correctly in PowerShell constrained mode.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/devblackops/Terminal-Icons/issues/138

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix issue to allow the module to work correctly. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

