### PR TITLE
Corrected .vsxproj.filters to .vcxproj.filters

### DIFF
--- a/Terminal-Icons/Data/iconThemes/devblackops.psd1
+++ b/Terminal-Icons/Data/iconThemes/devblackops.psd1
@@ -266,7 +266,7 @@
             '.vcxitems'             = 'nf-dev-visualstudio'
             '.vcxitems.filters'     = 'nf-dev-visualstudio'
             '.vcxproj'              = 'nf-dev-visualstudio'
-            '.vsxproj.filters'      = 'nf-dev-visualstudio'
+            '.vcxproj.filters'      = 'nf-dev-visualstudio'
 
             # CSharp
             '.cs'                   = 'nf-md-language_csharp'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected .vsxproj.filters to .vcxproj.filters

## Related Issue
[Issue 146](https://github.com/devblackops/Terminal-Icons/issues/146)

## Motivation and Context
Corrected to show the proper icon for .vcxproj.filters.

## How Has This Been Tested?
Didn't test. It is a one character change to devblackops.psd1.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

